### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   pre-commit:
+    permissions:
+      contents: read
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/reflex-dev/reflex-azure-auth/security/code-scanning/1](https://github.com/reflex-dev/reflex-azure-auth/security/code-scanning/1)

In general, the fix is to explicitly declare a minimal `permissions` block in the workflow so the automatically provided GITHUB_TOKEN has only the scopes required. For this workflow, the job just checks out code and runs pre‑commit locally, so it only needs read access to repository contents.

The best fix without changing existing functionality is to add a `permissions` section scoped to the `pre-commit` job (or at the root). To keep the change minimal and localized to the flagged region, we’ll add it directly under `pre-commit:` in `.github/workflows/pre-commit.yml`. We’ll set `contents: read`, which is sufficient for `actions/checkout` and running checks. No additional imports or methods are needed since this is a YAML workflow definition.

Concretely: in `.github/workflows/pre-commit.yml`, under `jobs:  pre-commit:`, insert a new `permissions:` block before `timeout-minutes: 30`, indented to match job-level keys. No other lines need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
